### PR TITLE
fix: resolve 3 source review findings from issue #30

### DIFF
--- a/unlaxer-common/src/main/java/org/unlaxer/context/ParseContext.java
+++ b/unlaxer-common/src/main/java/org/unlaxer/context/ParseContext.java
@@ -191,7 +191,7 @@ public class ParseContext implements
   }
   
   public  Source peek(CodePointIndex startIndexInclusive, CodePointIndex endIndexExclusive) {
-    return peek(startIndexInclusive, endIndexExclusive);
+    return getSource().peek(startIndexInclusive, endIndexExclusive);
   }
   
   static ThreadLocal<ParseContext> parseContextByThread = new ThreadLocal<>();

--- a/unlaxer-common/src/main/java/org/unlaxer/parser/combinator/ChainInterface.java
+++ b/unlaxer-common/src/main/java/org/unlaxer/parser/combinator/ChainInterface.java
@@ -2,12 +2,14 @@ package org.unlaxer.parser.combinator;
 
 import org.unlaxer.Parsed;
 import org.unlaxer.TokenKind;
+import org.unlaxer.TokenList;
 import org.unlaxer.context.ParseContext;
+import org.unlaxer.listener.TransactionListener;
 import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.Parsers;
 
 public interface ChainInterface extends Parser{
-	
+
 	@Override
 	public default Parsed parse(ParseContext parseContext,TokenKind tokenKind,boolean invertMatch) {
 
@@ -15,7 +17,11 @@ public interface ChainInterface extends Parser{
 
 		parseContext.startParse(this, parseContext, tokenKind, invertMatch);
 		parseContext.begin(this);
-		
+
+		if (this instanceof TransactionListener tl) {
+			tl.onBegin(parseContext, this);
+		}
+
 		Parsers children = getChildren();
 
 		for (Parser parser : children) {
@@ -25,12 +31,20 @@ public interface ChainInterface extends Parser{
 				break;
 			}
 			if (parsed.isFailed()) {
+				// Capture tokens before rollback clears the transaction frame
+				TokenList rolledBackTokens = TokenList.of(parseContext.getCurrent().getTokens());
 				parseContext.rollback(this);
+				if (this instanceof TransactionListener tl) {
+					tl.onRollback(parseContext, this, rolledBackTokens);
+				}
 				parseContext.endParse(this, Parsed.FAILED , parseContext, tokenKind, invertMatch);
 				return Parsed.FAILED;
 			}
 		}
 		Parsed committed = new Parsed(parseContext.commit(this,tokenKind));
+		if (this instanceof TransactionListener tl) {
+			tl.onCommit(parseContext, this, committed.getOriginalTokens());
+		}
 		parseContext.endParse(this, committed, parseContext, tokenKind, invertMatch);
 		return committed;
 	}

--- a/unlaxer-common/src/main/java/org/unlaxer/parser/elementary/SingleCharacterParser.java
+++ b/unlaxer-common/src/main/java/org/unlaxer/parser/elementary/SingleCharacterParser.java
@@ -2,6 +2,7 @@ package org.unlaxer.parser.elementary;
 
 import java.util.Optional;
 
+import org.unlaxer.CodePointIndex;
 import org.unlaxer.CodePointLength;
 import org.unlaxer.Name;
 import org.unlaxer.Source;
@@ -25,16 +26,43 @@ public abstract class SingleCharacterParser extends AbstractTokenParser
 
 	@Override
 	public Token getToken(ParseContext parseContext,TokenKind tokenKind , boolean invertMatch) {
-		
+
 		Source peeked = parseContext.peek(tokenKind , new CodePointLength(1));
-		Token token = 
-			peeked.isPresent() && (invertMatch ^ isMatch(peeked.charAt(0)))?
-				new Token(tokenKind , peeked, this) : 
+		Token token =
+			peeked.isPresent() && (invertMatch ^ isMatch(peeked.codePointAt(new CodePointIndex(0)).value()))?
+				new Token(tokenKind , peeked, this) :
 				Token.empty(tokenKind , parseContext.getCursor(TokenKind.consumed),this);
 		return token;
 	}
 
-	public abstract boolean isMatch(char target);
+	/**
+	 * Returns true if the given Unicode code point should be matched.
+	 *
+	 * <p>Subclasses that only handle BMP characters may override {@link #isMatch(char)} instead;
+	 * this default implementation delegates to {@code isMatch((char) codePoint)} for code points
+	 * that fit in a {@code char}, and returns {@code false} for supplementary code points
+	 * (U+10000 and above) so that existing subclasses remain correct without modification.
+	 *
+	 * @param codePoint the Unicode code point to test
+	 * @return {@code true} if the code point matches
+	 */
+	public boolean isMatch(int codePoint) {
+		if (Character.isBmpCodePoint(codePoint)) {
+			return isMatch((char) codePoint);
+		}
+		return false;
+	}
+
+	/**
+	 * Returns true if the given BMP character should be matched.
+	 *
+	 * @deprecated Override {@link #isMatch(int)} to support supplementary Unicode code points.
+	 *             This method is kept for backward compatibility with existing subclasses.
+	 */
+	@Deprecated
+	public boolean isMatch(char target) {
+		return false;
+	}
 
   @Override
   public Optional<String> expectedDisplayText() {


### PR DESCRIPTION
Closes #30

## Summary

- **Fix 1 (High): `ParseContext.peek` infinite recursion** — `peek(CodePointIndex, CodePointIndex)` was delegating back to itself causing `StackOverflowError`. Changed to delegate to `getSource().peek(...)`.

- **Fix 2 (Medium): `SingleCharacterParser` supplementary Unicode support** — `getToken` was using `peeked.charAt(0)` and `isMatch(char)` which fails for emoji and other non-BMP code points. Changed to use `codePointAt(new CodePointIndex(0)).value()` and a new `isMatch(int)` entry point. Existing `isMatch(char)` overrides remain functional via a backward-compatible default.

- **Fix 3 (Medium): `TransactionListener` auto-notification in `ChainInterface`** — `ChainInterface.parse()` now checks `this instanceof TransactionListener` and calls `onBegin`/`onCommit`/`onRollback` directly, eliminating the need for the `ScopeStore.registerDispatcher()` workaround.

## Test plan

- [ ] Verify `ParseContext.peek(CodePointIndex, CodePointIndex)` no longer throws `StackOverflowError`
- [ ] Verify `SingleCharacterParser` subclasses matching BMP chars still pass existing tests
- [ ] Verify a parser implementing both `ChainInterface` and `TransactionListener` receives events without `ScopeStore.registerDispatcher()`
- [ ] Run `mvn test` on `unlaxer-common` and `unlaxer-dsl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)