### PR TITLE
fix(codegen): heterogeneous @value を実 AST ノードへ解決 (#43系; 3.0.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versions are published to Maven Central (`org.unlaxer:unlaxer-common`, `org.unla
 
 ---
 
+## [3.0.6] - 2026-06-26
+
+### Fixed
+
+- **MapperGenerator dropped heterogeneous `@value` captures to source text (#43 family)**: a `@value` bound to a transparent choice rule with no `@mapping` of its own whose alternatives map to several different AST classes (e.g. `BooleanFactor ::= … | BooleanComparable @value`, where `BooleanComparable ::= InMethod | IsPresentFunction | …`) was emitted as `stripQuotes(firstTokenText(token))`, silently flattening the matched node (an `InExpr`, `IsPresentExpr`, …) to its source string. The generated mapper now resolves the real node via a new `mapTransparentValue(token)` helper (`mapToken` → `findBestMappedToken` → text fallback), so the `Object`-typed field carries the actual AST node. Downstream (tinyexpression #32) this makes `.in()` / `isPresent` / dot-predicate boolean factors inside `if(...)` conditions evaluate faithfully on the AST instead of via a source re-parse. New `MapperElementUtil.isTransparentMappedChoice` gates the change (≥2 distinct mapped alternatives → `Object` field, so emitting a node-or-text value is type-safe). Golden mapper snapshots updated.
+
+---
+
 ## [3.0.5] - 2026-06-25
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 	</developers>
 
 	<properties>
-		<revision>3.0.5</revision> <!-- ここを変えるだけで全体が変わるようになります -->
+		<revision>3.0.6</revision> <!-- ここを変えるだけで全体が変わるようになります -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>

--- a/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperElementUtil.java
+++ b/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperElementUtil.java
@@ -358,6 +358,16 @@ class MapperElementUtil {
                 return targetType + ".fromText(stripQuotes(firstTokenText(" + tokenVar + ")))";
             }
         }
+        // A heterogeneous Object @value bound to a transparent choice rule (no @mapping of
+        // its own, alternatives mapping to several different AST classes — e.g. a
+        // BooleanComparable ::= InMethod | IsPresentFunction | ... rule) was previously
+        // flattened to firstTokenText, silently dropping the real node it wraps. Resolve the
+        // matched alternative's node instead. Object-typed, so a node or the text fallback
+        // both fit the field. (unlaxer-parser #43 family / tinyexpression #32)
+        if ("Object".equals(targetType) && element instanceof RuleRefElement transparentRef
+            && isTransparentMappedChoice(ruleByName.get(transparentRef.name()), mappedClassByRuleName)) {
+            return "mapTransparentValue(" + tokenVar + ")";
+        }
         if (!"String".equals(targetType)) {
             return mapExpressionForElement(element, tokenVar, mappedClassByRuleName, tokenDeclByName, ruleByName);
         }
@@ -368,6 +378,33 @@ class MapperElementUtil {
             }
         }
         return "stripQuotes(firstTokenText(" + tokenVar + "))";
+    }
+
+    /**
+     * True if {@code rule} is a "transparent choice" used as a heterogeneous {@code Object}
+     * capture: it has no {@code @mapping} of its own and its body is a choice whose
+     * single-RuleRef alternatives map to two or more distinct AST classes. Such a capture's
+     * field is inferred as {@code Object}, so the matched alternative's node must be resolved
+     * at runtime rather than dropped to {@code firstTokenText}. (unlaxer-parser #43 family)
+     */
+    static boolean isTransparentMappedChoice(RuleDecl rule, Map<String, String> mappedClassByRuleName) {
+        if (rule == null || getMappingAnnotation(rule).isPresent()) {
+            return false;
+        }
+        if (!(rule.body() instanceof ChoiceBody choice)) {
+            return false;
+        }
+        java.util.Set<String> mappedClasses = new java.util.LinkedHashSet<>();
+        for (SequenceBody alternative : choice.alternatives()) {
+            if (alternative.elements().size() != 1) {
+                continue;
+            }
+            AtomicElement element = alternative.elements().get(0).element();
+            if (element instanceof RuleRefElement ref && mappedClassByRuleName.containsKey(ref.name())) {
+                mappedClasses.add(mappedClassByRuleName.get(ref.name()));
+            }
+        }
+        return mappedClasses.size() >= 2;
     }
 
     static boolean isIdentifierToken(TokenDecl tokenDecl) {

--- a/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperGenerator.java
+++ b/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperGenerator.java
@@ -86,6 +86,9 @@ public class MapperGenerator implements CodeGenerator {
         // ----- findBestMappedToken -----
         sb.append(MapperRuleEmitter.emitFindBestMappedToken(astClass));
 
+        // ----- mapTransparentValue (heterogeneous @value node resolution) -----
+        sb.append(MapperRuleEmitter.emitMapTransparentValue(astClass));
+
         // ----- Mapping Methods -----
         sb.append(MapperRuleEmitter.emitMappingMethods(grammar, astClass, parsersClass,
             mappingRules, allMappingRules, mappedClassByRuleName, tokenDeclByName, ruleByName));

--- a/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperRuleEmitter.java
+++ b/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperRuleEmitter.java
@@ -59,6 +59,45 @@ class MapperRuleEmitter {
     }
 
     /**
+     * mapTransparentValue() を生成する。@mapping を持たない透過的 choice ルールを
+     * 値として捉えた heterogeneous(Object) フィールド向けに、マッチした選択肢の実 AST
+     * ノードを解決する。ノードが見つからなければ firstTokenText にフォールバック。
+     * (unlaxer-parser #43 family / tinyexpression #32)
+     */
+    static String emitMapTransparentValue(String astClass) {
+        IndentedWriter w = new IndentedWriter(1);
+        w.line("private static Object mapTransparentValue(Token token) {");
+        w.indent();
+        w.line("if (token == null) {");
+        w.indent();
+        w.line("return null;");
+        w.dedent();
+        w.line("}");
+        w.line(astClass + " direct = mapToken(token);");
+        w.line("if (direct != null) {");
+        w.indent();
+        w.line("return direct;");
+        w.dedent();
+        w.line("}");
+        w.line("Token best = findBestMappedToken(token, null);");
+        w.line("if (best != null) {");
+        w.indent();
+        w.line(astClass + " mapped = mapToken(best);");
+        w.line("if (mapped != null) {");
+        w.indent();
+        w.line("return mapped;");
+        w.dedent();
+        w.line("}");
+        w.dedent();
+        w.line("}");
+        w.line("return stripQuotes(firstTokenText(token));");
+        w.dedent();
+        w.line("}");
+        w.blankLine();
+        return w.build();
+    }
+
+    /**
      * findBestMappedToken 関連メソッドと MappingCandidate 内部クラスを生成する。
      */
     static String emitFindBestMappedToken(String astClass) {

--- a/unlaxer-dsl/src/test/resources/golden/mapper_right_assoc_snapshot.java.txt
+++ b/unlaxer-dsl/src/test/resources/golden/mapper_right_assoc_snapshot.java.txt
@@ -123,6 +123,24 @@ public class SnapshotRightAssocMapper {
         }
     }
 
+    private static Object mapTransparentValue(Token token) {
+        if (token == null) {
+            return null;
+        }
+        SnapshotRightAssocAST direct = mapToken(token);
+        if (direct != null) {
+            return direct;
+        }
+        Token best = findBestMappedToken(token, null);
+        if (best != null) {
+            SnapshotRightAssocAST mapped = mapToken(best);
+            if (mapped != null) {
+                return mapped;
+            }
+        }
+        return stripQuotes(firstTokenText(token));
+    }
+
     // =========================================================================
     // Mapping Methods
     // =========================================================================

--- a/unlaxer-dsl/src/test/resources/golden/mapper_snapshot.java.txt
+++ b/unlaxer-dsl/src/test/resources/golden/mapper_snapshot.java.txt
@@ -126,6 +126,24 @@ public class SnapshotMapper {
         }
     }
 
+    private static Object mapTransparentValue(Token token) {
+        if (token == null) {
+            return null;
+        }
+        SnapshotAST direct = mapToken(token);
+        if (direct != null) {
+            return direct;
+        }
+        Token best = findBestMappedToken(token, null);
+        if (best != null) {
+            SnapshotAST mapped = mapToken(best);
+            if (mapped != null) {
+                return mapped;
+            }
+        }
+        return stripQuotes(firstTokenText(token));
+    }
+
     // =========================================================================
     // Mapping Methods
     // =========================================================================


### PR DESCRIPTION
## 概要
`@value` が「@mapping を持たない透過的 choice ルール（選択肢が複数の異なる AST クラスにマップ）」に束縛されている場合（例: `BooleanFactor ::= … | BooleanComparable @value`、`BooleanComparable ::= InMethod | IsPresentFunction | …`）、生成マッパーが `stripQuotes(firstTokenText(token))` でマッチしたノード（InExpr 等）を**ソース文字列に潰していた**。Object 型フィールドゆえ消費側は再パースを強いられていた。

## 修正
- `MapperGenerator` が該当キャプチャに `mapTransparentValue(token)` を emit: `mapToken` → `findBestMappedToken`+`mapToken` → firstTokenText フォールバック。
- `MapperElementUtil.isTransparentMappedChoice` で gate（≥2 の異なるマップ先 ⇒ 推論型 Object ⇒ node-or-text 値が型安全）。Object 型 @value のみ対象でフィールド型変更なし。

## downstream 効果 (tinyexpression #32)
`if(...)` 条件内の `.in()`/`isPresent`/dot-predicate boolean 因子が AST 経路で忠実評価に。if-source shadow 無効化で計測: **P4BackendParityTest 2→0**、**P4AstEvaluatorCalculatorTest 10→6**。

## 検証
- フル unlaxer-parser ビルド（ubnf-vscode / tinycalc-vscode 含む）緑
- unlaxer-dsl テスト緑、golden mapper snapshot 更新
- blast radius: tinyexpression-p4 では `toBooleanFactorExpr` の1箇所のみ

関連: #43, tinyexpression#32

🤖 Generated with [Claude Code](https://claude.com/claude-code)