### PR TITLE
fix(codegen): widen transparent-choice assoc operands to Object node (#43 family; #32; 3.0.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Versions are published to Maven Central (`org.unlaxer:unlaxer-common`, `org.unla
 
 ---
 
+## [3.0.7] - 2026-06-26
+
+### Fixed
+
+- **Associative folds flattened transparent-choice operands to source text (#43 family; tinyexpression #32)**: a `@leftAssoc`/`@rightAssoc` rule whose operands reference a transparent mapped choice with no `@mapping` of its own (e.g. `StringExpression ::= StringTerm @left { '+' @op StringTerm @right }`, where `StringTerm ::= StringMatchExpression | SliceExpression | VariableRef | …`) inferred its operand fields as `String` and emitted `stripQuotes(firstTokenText(token))`, silently dropping the matched node. Such operands are now inferred as `Object` and resolved to their real AST node via the existing `mapTransparentValue(token)` helper. The same widening applies to comparison rules over transparent choices (e.g. `BooleanEqualityExpression ::= BooleanComparable @left EqualityOp @op BooleanComparable @right`). Downstream (tinyexpression #32) this makes string concatenation and boolean-equality operands evaluate faithfully on the AST instead of via a source re-parse.
+  - `MapperTypeResolver.inferTypeFromElement` and `ASTGenerator.inferTypeFromElement` now yield `Object` (not `String`) for a reference to a transparent mapped choice, via the new `MapperTypeResolver.isTransparentMappedChoice` (same ≥2-distinct-mapped-alternatives criterion as `MapperElementUtil.isTransparentMappedChoice`).
+  - `MapperRuleEmitter`'s assoc-fold emission now maps left/right operands through `mapExpressionForTargetType` (which routes `Object` + transparent choice to `mapTransparentValue`), delegating to the prior `mapExpressionForElement` behavior for AST-class / `String` operand types — so number-style and node-operand folds are unchanged.
+
+---
+
 ## [3.0.6] - 2026-06-26
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 	</developers>
 
 	<properties>
-		<revision>3.0.6</revision> <!-- ここを変えるだけで全体が変わるようになります -->
+		<revision>3.0.7</revision> <!-- ここを変えるだけで全体が変わるようになります -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>

--- a/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/ASTGenerator.java
+++ b/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/ASTGenerator.java
@@ -507,7 +507,14 @@ public class ASTGenerator implements CodeGenerator {
                     yield astClassName + "." + mapping.get().className();
                 }
                 String tokenType = MapperTypeResolver.inferTypeFromTokenName(grammar, r.name());
-                yield tokenType != null ? tokenType : "String";
+                if (tokenType != null) {
+                    yield tokenType;
+                }
+                // 透過 mapped choice（異種選択肢）は単一スカラーに収束しない → Object
+                if (MapperTypeResolver.isTransparentMappedChoice(grammar, r.name())) {
+                    yield "Object";
+                }
+                yield "String";
             }
             case RepeatElement rep -> {
                 String inner = inferTypeFromBody(grammar, rep.body());

--- a/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperRuleEmitter.java
+++ b/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperRuleEmitter.java
@@ -279,9 +279,15 @@ class MapperRuleEmitter {
             String rightParserClass = MapperElementUtil.parserClassLiteral(assocShape.rightElement(), parsersClass, tokenDeclByName, ruleByName)
                 .orElse(ruleParserClass);
 
+            // Use target-type-aware mapping so that Object operands bound to a transparent
+            // mapped choice (e.g. StringConcatExpr's StringTerm operands) resolve the real
+            // matched node via mapTransparentValue instead of being flattened to source text.
+            // For AST-class / String target types this delegates to mapExpressionForElement,
+            // preserving existing fold behavior. (tinyexpression #32 string-concat widening)
             String leftMapper = heterogeneousOperand
                 ? operandHelper + "(leftToken)"
-                : MapperElementUtil.mapExpressionForElement(
+                : MapperElementUtil.mapExpressionForTargetType(
+                    leftType,
                     assocShape.leftElement(),
                     "leftToken",
                     mappedClassByRuleName,
@@ -289,7 +295,8 @@ class MapperRuleEmitter {
                     ruleByName);
             String rightMapper = heterogeneousOperand
                 ? operandHelper + "(rightToken)"
-                : MapperElementUtil.mapExpressionForElement(
+                : MapperElementUtil.mapExpressionForTargetType(
+                    rightType,
                     assocShape.rightElement(),
                     "rightToken",
                     mappedClassByRuleName,

--- a/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperTypeResolver.java
+++ b/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperTypeResolver.java
@@ -92,7 +92,14 @@ class MapperTypeResolver {
                 }
                 // token 型推論: parser class 名から Java 型を導出
                 String tokenType = inferTypeFromTokenName(grammar, ruleRefElement.name());
-                yield tokenType != null ? tokenType : "String";
+                if (tokenType != null) {
+                    yield tokenType;
+                }
+                // 透過 mapped choice（異種選択肢）は単一スカラーに収束しない → Object
+                if (isTransparentMappedChoice(grammar, ruleRefElement.name())) {
+                    yield "Object";
+                }
+                yield "String";
             }
             case RepeatElement repeatElement -> {
                 String inner = inferTypeFromBody(grammar, repeatElement.body());
@@ -141,6 +148,50 @@ class MapperTypeResolver {
             .filter(type -> type != null)
             .findFirst()
             .orElse(null);
+    }
+
+    /**
+     * 参照先ルールが「透過 mapped choice」かどうか判定する。
+     * すなわち、自身に @mapping を持たず、本体が choice で、その単一 RuleRef 選択肢が
+     * ≥2 の異なる AST クラス（@mapping）にマップする場合 true。
+     * このようなルール参照は単一のスカラー型に収束しないため、型は Object とすべき。
+     * 例: StringTerm（StringMatchExpression | SliceExpression | VariableRef | ... の透過 choice）。
+     *
+     * 判定基準は {@link MapperElementUtil#isTransparentMappedChoice} と揃えており、
+     * 型推論（フィールド型）と mapper 生成式（mapTransparentValue）が一致するようにしている。
+     */
+    static boolean isTransparentMappedChoice(GrammarDecl grammar, String ruleName) {
+        Optional<RuleDecl> ruleOpt = grammar.rules().stream()
+            .filter(r -> r.name().equals(ruleName))
+            .findFirst();
+        if (ruleOpt.isEmpty()) {
+            return false;
+        }
+        RuleDecl rule = ruleOpt.get();
+        // 自身に @mapping があるなら透過ではない（その AST クラスに解決される）
+        boolean hasMapping = rule.annotations().stream().anyMatch(a -> a instanceof MappingAnnotation);
+        if (hasMapping) {
+            return false;
+        }
+        if (!(rule.body() instanceof ChoiceBody choice)) {
+            return false;
+        }
+        Set<String> mappedClasses = new LinkedHashSet<>();
+        for (SequenceBody alt : choice.alternatives()) {
+            if (alt.elements().size() != 1) {
+                continue;
+            }
+            if (alt.elements().get(0).element() instanceof RuleRefElement ref) {
+                grammar.rules().stream()
+                    .filter(r -> r.name().equals(ref.name()))
+                    .flatMap(r -> r.annotations().stream())
+                    .filter(a -> a instanceof MappingAnnotation)
+                    .map(a -> ((MappingAnnotation) a).className())
+                    .findFirst()
+                    .ifPresent(mappedClasses::add);
+            }
+        }
+        return mappedClasses.size() >= 2;
     }
 
     /** TypeofElement を参照するキャプチャ名から実際の AtomicElement に解決する */


### PR DESCRIPTION
## 概要

`@leftAssoc`/`@rightAssoc` の operand が透過 mapped choice（@mapping 無し・≥2 異種ASTクラスにマップ。例 `StringExpression ::= StringTerm @left { '+' @op StringTerm @right }` の `StringTerm`）を参照する場合、operand フィールドが `String` と推論され `stripQuotes(firstTokenText(token))` で出力 → 実 AST ノードを source text に潰していた。これを `Object` と推論し、既存 `mapTransparentValue(token)` で実ノードへ解決する。

## 変更点
- **`MapperTypeResolver.isTransparentMappedChoice`（新設）**: `MapperElementUtil.isTransparentMappedChoice` と同一基準（単一 RuleRef 選択肢が ≥2 の異なる @mapping クラスにマップ）で透過 choice を検出。
- **`ASTGenerator` / `MapperTypeResolver` の `inferTypeFromElement`**: 透過 mapped choice 参照を `String` でなく `Object` と推論。
- **`MapperRuleEmitter` assoc fold**: left/right operand を `mapExpressionForTargetType` 経由でマップ（Object+透過 choice → `mapTransparentValue`、AST クラス/String 型では従来の `mapExpressionForElement` に委譲）。number-style / node-operand fold は不変。

比較ルール（`BooleanEqualityExpression ::= BooleanComparable @left EqualityOp @op BooleanComparable @right`）にも同様に適用される。

## 検証
- unlaxer-dsl 内部フルビルド（ubnf/tinycalc 生成+コンパイル）：成功、golden 差分なし、全テスト緑。
- downstream tinyexpression（3.0.7-SNAPSHOT）`mvn verify`：630 tests、新規失敗ゼロ（既知の #38 のみ）。`check-test-baseline.sh` ゲート OK。

closes は無し（#32 は継続課題）。#43 family の codegen 根治を継続。

🤖 Generated with [Claude Code](https://claude.com/claude-code)