### PR TITLE
fix(codegen): structural-position capture resolution + identifier wrapper ref (#32; 3.0.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versions are published to Maven Central (`org.unlaxer:unlaxer-common`, `org.unla
 
 ---
 
+## [3.0.8] - 2026-06-27
+
+### Fixed
+
+- **Mapper captures used a global descendant index that miscounted across nesting (tinyexpression #32, load-bearing `if` shadow)**: scalar/optional capture resolution emitted `findDescendantByIndex(token, ParserClass, n)`, which recurses through ALL descendants. When the captured parser class also appears nested inside a *sibling* capture's subtree, the global Nth-of-class index points at the wrong node. Concretely, `IfExpression`'s `@thenExpr`/`@elseExpr` (`Expression`) were mis-resolved to an `Expression` nested inside the `@condition` — e.g. `if(min(0,0)==0){1}else{0}` mapped `thenExpr` to a `0` from the condition instead of the literal `1`, so the pure-AST evaluation took the wrong branch. Captures are direct children of the rule's Chain, so resolution is now **structural-position based**: new `findCapturedToken` prefers the rule token's direct children (`findDirectDescendants`) and only falls back to the global descendant index when no direct child of the class exists — backward-compatible where the old index was already correct. Fixes if-branch and slice-index resolution on the AST path (downstream tinyexpression: `min`/`max` and many `if(...)` cases now evaluate faithfully without the source shadow).
+- **`@name`/identifier-token captures resolved to empty on the AST path (#43 family; tinyexpression #32)**: for a fully-qualified token parser, the parse tree holds the generated *wrapper* subclass (`<Grammar>Parsers.IdentifierParser`, per ParserTokenEmitter / `resolveParserClass` "Plan S"), but `MapperElementUtil.parserClassLiteral` referenced the base `org.unlaxer.parser.clang.IdentifierParser`. Since `findDescendants` matches by exact `getClass()`, the capture silently came back empty (e.g. `VariableRefExpr.name`, import `@alias`/`@method`), and only the source-snippet shadow recovered it. It now mirrors `resolveParserClass` exactly: the wrapper class for fully-qualified token parsers, the base class for short-named ones.
+
+---
+
 ## [3.0.7] - 2026-06-26
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 	</developers>
 
 	<properties>
-		<revision>3.0.7</revision> <!-- ここを変えるだけで全体が変わるようになります -->
+		<revision>3.0.8</revision> <!-- ここを変えるだけで全体が変わるようになります -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>

--- a/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperElementUtil.java
+++ b/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperElementUtil.java
@@ -287,6 +287,19 @@ class MapperElementUtil {
                 if (tokenDeclByName.containsKey(ruleRefElement.name())) {
                     TokenDecl tokenDecl = tokenDeclByName.get(ruleRefElement.name());
                     if (isIdentifierToken(tokenDecl)) {
+                        // Mirror ParserRuleEmitter.resolveParserClass exactly so the mapper
+                        // references the SAME class the parser put in the tree (findDescendants
+                        // matches by exact getClass()). A fully-qualified token parser is wrapped
+                        // in a generated subclass (ParserTokenEmitter, "Plan S: findDescendants
+                        // 互換"); a short-named one is referenced directly via the parser's import.
+                        // Previously this always emitted the base clang class, so for FQN tokens
+                        // the capture (VariableRef @name, import @alias/@method) silently resolved
+                        // to empty and only the source-snippet shadow recovered it.
+                        // (tinyexpression #32: empty VariableRefExpr.name on the pure AST path)
+                        String parserClass = tokenDecl.parserClass();
+                        if (parserClass != null && parserClass.contains(".")) {
+                            yield Optional.of(parsersClass + "." + ParserCodegenUtil.toParserClassName(ruleRefElement.name()) + ".class");
+                        }
                         yield Optional.of("org.unlaxer.parser.clang.IdentifierParser.class");
                     }
                     yield Optional.empty();

--- a/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperRuleEmitter.java
+++ b/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperRuleEmitter.java
@@ -678,7 +678,7 @@ class MapperRuleEmitter {
             w.line("if (!found_" + MapperElementUtil.safeName(param) + ") {");
             w.indent();
             w.line("Token " + tokenVarName
-                + " = findDescendantByIndex(token, " + parserClass + ", "
+                + " = findCapturedToken(token, " + parserClass + ", "
                 + parserOccurrenceIndex + ");");
             w.line("if (" + tokenVarName + " != null) {");
             w.indent();
@@ -724,7 +724,7 @@ class MapperRuleEmitter {
             w.line("if (!assigned_" + MapperElementUtil.safeName(param) + ") {");
             w.indent();
             w.line("Token " + tokenVarName
-                + " = findDescendantByIndex(token, " + parserClass + ", "
+                + " = findCapturedToken(token, " + parserClass + ", "
                 + parserOccurrenceIndex + ");");
             w.line("if (" + tokenVarName + " != null) {");
             w.indent();
@@ -915,6 +915,37 @@ class MapperRuleEmitter {
         w.dedent();
         w.line("}");
         w.line("return descendants.get(index);");
+        w.dedent();
+        w.line("}");
+        w.blankLine();
+
+        // Resolve a captured token by STRUCTURAL POSITION: prefer the rule token's direct
+        // children, falling back to the global descendant index only when no direct child of
+        // the parser class exists. A global descendant index miscounts whenever the captured
+        // parser class also appears nested inside a SIBLING capture's subtree — e.g.
+        // IfExpression's @thenExpr/@elseExpr (Expression) vs the Expressions inside its
+        // @condition (min(0,0)==0), or a nested slice's outer index vs the inner slice's.
+        // Captures are direct children of the rule's Chain, so direct-first resolution is
+        // both correct there and backward-compatible elsewhere. (tinyexpression #32)
+        w.line("static Token findCapturedToken(Token token, Class<? extends Parser> parserClass, int index) {");
+        w.indent();
+        w.line("if (index < 0) {");
+        w.indent();
+        w.line("return null;");
+        w.dedent();
+        w.line("}");
+        w.line("List<Token> direct = findDirectDescendants(token, parserClass);");
+        w.line("if (index < direct.size()) {");
+        w.indent();
+        w.line("return direct.get(index);");
+        w.dedent();
+        w.line("}");
+        w.line("if (!direct.isEmpty()) {");
+        w.indent();
+        w.line("return null;");
+        w.dedent();
+        w.line("}");
+        w.line("return findDescendantByIndex(token, parserClass, index);");
         w.dedent();
         w.line("}");
         w.blankLine();

--- a/unlaxer-dsl/src/test/resources/golden/mapper_right_assoc_snapshot.java.txt
+++ b/unlaxer-dsl/src/test/resources/golden/mapper_right_assoc_snapshot.java.txt
@@ -271,6 +271,20 @@ public class SnapshotRightAssocMapper {
         return descendants.get(index);
     }
 
+    static Token findCapturedToken(Token token, Class<? extends Parser> parserClass, int index) {
+        if (index < 0) {
+            return null;
+        }
+        List<Token> direct = findDirectDescendants(token, parserClass);
+        if (index < direct.size()) {
+            return direct.get(index);
+        }
+        if (!direct.isEmpty()) {
+            return null;
+        }
+        return findDescendantByIndex(token, parserClass, index);
+    }
+
     static String firstTokenText(Token token) {
         if (token == null) {
             return null;

--- a/unlaxer-dsl/src/test/resources/golden/mapper_snapshot.java.txt
+++ b/unlaxer-dsl/src/test/resources/golden/mapper_snapshot.java.txt
@@ -281,6 +281,20 @@ public class SnapshotMapper {
         return descendants.get(index);
     }
 
+    static Token findCapturedToken(Token token, Class<? extends Parser> parserClass, int index) {
+        if (index < 0) {
+            return null;
+        }
+        List<Token> direct = findDirectDescendants(token, parserClass);
+        if (index < direct.size()) {
+            return direct.get(index);
+        }
+        if (!direct.isEmpty()) {
+            return null;
+        }
+        return findDescendantByIndex(token, parserClass, index);
+    }
+
     static String firstTokenText(Token token) {
         if (token == null) {
             return null;


### PR DESCRIPTION
## 概要
生成マッパーの AST 経路忠実度を2点修正（#32 の load-bearing if-shadow 中核）。

### 1. グローバル子孫索引の誤カウント（if 分岐バグの根本）
scalar/optional capture が `findDescendantByIndex`（全子孫を再帰）を使うため、捕捉対象の parser クラスが**兄弟 capture のサブツリー内**に現れると索引がずれる。例：`IfExpression` の `@thenExpr`/`@elseExpr`(Expression) が `@condition` 内の Expression を拾い、`if(min(0,0)==0){1}else{0}` の thenExpr が条件内の `0` に誤マップ → 純AST評価で誤分岐。
- 新ヘルパー **`findCapturedToken`**：直接子（`findDirectDescendants`）優先で構造位置解決、直接子が無い場合のみ従来のグローバル索引にフォールバック（後方互換）。
- if 分岐・slice index 解決を是正。downstream: `min`/`max` と多数の `if(...)` が source shadow 無しで正しく評価。

### 2. identifier トークン capture が空になる（#43 family）
FQN トークンの parser はツリー上は生成ラッパー（`<Grammar>Parsers.IdentifierParser`）。だが `parserClassLiteral` は base `org.unlaxer.parser.clang.IdentifierParser` を参照していた。`findDescendants` は `getClass()` 完全一致なので capture が空に（`VariableRefExpr.name`、import `@alias`/`@method`）→ source shadow のみが復元。`resolveParserClass` と同一判定に（FQN→ラッパー、短縮名→base）。

## 検証
- unlaxer-dsl 全 746 テスト緑（golden 更新済み）、内部フルビルド（ubnf/tinycalc）緑・compile 検証緑。
- tinyexpression baseline ゲート緑（新規失敗ゼロ、既知 #38 のみ）。
- if-source shadow OFF の calc 失敗：4 → **2**（testMin/testMax 解消）。残り testStringSlice（ネスト slice value=多ルール）/ testTypeInference（var宣言）は別タスク。

🤖 Generated with [Claude Code](https://claude.com/claude-code)