### PR TITLE
fix(codegen): multi-rule plain dispatch + bounded capture fallback (#32 nested slice; 3.0.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versions are published to Maven Central (`org.unlaxer:unlaxer-common`, `org.unla
 
 ---
 
+## [3.0.9] - 2026-06-27
+
+### Fixed
+
+- **Multiple non-assoc rules mapping to one AST class only generated from one rule (tinyexpression #32, nested slice)**: when two `@mapping` rules target the same class with DIFFERENT capture structures — e.g. `SliceExpr`: `SliceBaseExpression`'s `@value` is a `SliceBaseReceiver` while `SliceNestedExpression`'s `@value` is a `SliceBaseExpression` (the mapped class itself) — the generated `to<Class>` was emitted from a single representative rule and mis-resolved tokens of the other rule (a nested slice `'gateman'[::-1][0:4]` dropped the inner `[::-1]`, grabbing the innermost receiver). `emitPlainMappingBody` now dispatches each additional non-assoc rule by `token.parser.getClass()` (resolution extracted to `emitPlainMappingResolution`), with the representative rule as the unguarded fallback — exactly one rule is guarded and the other falls through, so the result is correct regardless of representative choice. Single-rule and structurally-identical multi-rule classes (e.g. `IfExpr`'s `ArgumentTernary`) are behavior-unchanged.
+- **`findCapturedToken` fallback leaked an absent capture into a nested sub-expression**: the global descendant fallback let an outer slice's ABSENT `@step` (`[0:4]`) match the inner `[::-1]`'s step. The fallback is now a BOUNDED descendant search (`findDescendantsBounded`) that stops at `CAPTURE_BOUNDARY_PARSERS` — the set of all rule parser classes that map to their own AST node — so a capture missing at this level cannot cross into a separate captured sub-node. Captures genuinely nested under anonymous wrappers (Optional/Group/Repeat) still resolve. `MapperRuleEmitter.emitUtilities` now takes `(parsersClass, mappedRuleNames)`.
+
+---
+
 ## [3.0.8] - 2026-06-27
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 	</developers>
 
 	<properties>
-		<revision>3.0.8</revision> <!-- ここを変えるだけで全体が変わるようになります -->
+		<revision>3.0.9</revision> <!-- ここを変えるだけで全体が変わるようになります -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>

--- a/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperGenerator.java
+++ b/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperGenerator.java
@@ -97,7 +97,7 @@ public class MapperGenerator implements CodeGenerator {
         sb.append(MapperRuleEmitter.emitFoldHelpers(grammar, astClass, mappingRules));
 
         // ----- Utilities -----
-        sb.append(MapperRuleEmitter.emitUtilities());
+        sb.append(MapperRuleEmitter.emitUtilities(parsersClass, mappedClassByRuleName.keySet()));
 
         sb.append("}\n");
 

--- a/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperRuleEmitter.java
+++ b/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperRuleEmitter.java
@@ -220,7 +220,7 @@ class MapperRuleEmitter {
                     rightAssoc, allMappingRules, mappedClassByRuleName, tokenDeclByName, ruleByName);
             } else {
                 emitPlainMappingBody(w, grammar, astClass, parsersClass, className, rule, mapping,
-                    mappedClassByRuleName, tokenDeclByName, ruleByName);
+                    allMappingRules, mappedClassByRuleName, tokenDeclByName, ruleByName);
             }
 
             w.dedent();
@@ -521,6 +521,41 @@ class MapperRuleEmitter {
     private static void emitPlainMappingBody(IndentedWriter w, GrammarDecl grammar,
             String astClass, String parsersClass, String className,
             RuleDecl rule, MappingAnnotation mapping,
+            Map<String, List<RuleDecl>> allMappingRules,
+            Map<String, String> mappedClassByRuleName,
+            Map<String, TokenDecl> tokenDeclByName, Map<String, RuleDecl> ruleByName) {
+
+        // Multiple non-assoc rules can map to the same AST class with DIFFERENT capture
+        // structures (e.g. SliceExpr: SliceBaseExpression's @value is a SliceBaseReceiver,
+        // SliceNestedExpression's @value is a SliceBaseExpression i.e. the mapped class
+        // itself). A single resolution body generated from one representative rule mis-resolves
+        // tokens of the other rule. Dispatch each ADDITIONAL rule by the token's parser class;
+        // the representative rule stays the unguarded fallback. Exactly one rule is guarded and
+        // the other falls through, so the result is correct regardless of which is representative.
+        // Single-rule classes and structurally-identical rules (e.g. IfExpr's ArgumentTernary)
+        // are unaffected in behavior. (tinyexpression #32: nested slice value)
+        List<RuleDecl> additionalRules = allMappingRules.getOrDefault(className, List.of()).stream()
+            .filter(r -> r != rule)
+            .filter(r -> {
+                MappingAnnotation m = MapperElementUtil.getMappingAnnotation(r).orElse(null);
+                return !MapperElementUtil.isLeftAssocRule(r, m) && !MapperElementUtil.isRightAssocRule(r, m);
+            })
+            .toList();
+        for (RuleDecl additionalRule : additionalRules) {
+            w.line("if (token.parser.getClass() == " + parsersClass + "." + additionalRule.name() + "Parser.class) {");
+            w.indent();
+            emitPlainMappingResolution(w, grammar, astClass, parsersClass, className, additionalRule, mapping,
+                mappedClassByRuleName, tokenDeclByName, ruleByName);
+            w.dedent();
+            w.line("}");
+        }
+        emitPlainMappingResolution(w, grammar, astClass, parsersClass, className, rule, mapping,
+            mappedClassByRuleName, tokenDeclByName, ruleByName);
+    }
+
+    private static void emitPlainMappingResolution(IndentedWriter w, GrammarDecl grammar,
+            String astClass, String parsersClass, String className,
+            RuleDecl rule, MappingAnnotation mapping,
             Map<String, String> mappedClassByRuleName,
             Map<String, TokenDecl> tokenDeclByName, Map<String, RuleDecl> ruleByName) {
 
@@ -803,11 +838,61 @@ class MapperRuleEmitter {
     /**
      * ユーティリティメソッド群（findDescendants, firstTokenText 等）を生成する。
      */
-    static String emitUtilities() {
+    static String emitUtilities(String parsersClass, java.util.Set<String> mappedRuleNames) {
         IndentedWriter w = new IndentedWriter(1);
         w.line("// =========================================================================");
         w.line("// Utilities");
         w.line("// =========================================================================");
+        w.blankLine();
+
+        // Parser classes of rules that map to their own AST node. A capture's bounded
+        // descendant search must NOT cross into one of these, because it is a SEPARATE
+        // captured sub-expression — e.g. a nested slice's outer @step search must stop at
+        // the inner slice (SliceBaseExpression) rather than leak in and grab its step.
+        w.line("private static final java.util.Set<Class<?>> CAPTURE_BOUNDARY_PARSERS = java.util.Set.of(");
+        w.indent();
+        java.util.List<String> boundaryRules = new java.util.ArrayList<>(mappedRuleNames);
+        if (boundaryRules.isEmpty()) {
+            // Set.of() with no args is fine, but keep a stable form.
+            w.dedent();
+            w.line(");");
+        } else {
+            for (int i = 0; i < boundaryRules.size(); i++) {
+                String suffix = i < boundaryRules.size() - 1 ? "," : "";
+                w.line(parsersClass + "." + boundaryRules.get(i) + "Parser.class" + suffix);
+            }
+            w.dedent();
+            w.line(");");
+        }
+        w.blankLine();
+
+        // Like findDescendants, but stops at capture-boundary tokens (separate mapped nodes),
+        // so a capture absent at this level does not leak into a nested sub-expression of the
+        // same parser class. Used as findCapturedToken's fallback. (tinyexpression #32)
+        w.line("static List<Token> findDescendantsBounded(Token token, Class<? extends Parser> parserClass) {");
+        w.indent();
+        w.line("List<Token> results = new ArrayList<>();");
+        w.line("if (token == null) {");
+        w.indent();
+        w.line("return results;");
+        w.dedent();
+        w.line("}");
+        w.line("for (Token child : token.filteredChildren) {");
+        w.indent();
+        w.line("if (child.parser.getClass() == parserClass) {");
+        w.indent();
+        w.line("results.add(child);");
+        w.dedent();
+        w.line("} else if (!CAPTURE_BOUNDARY_PARSERS.contains(child.parser.getClass())) {");
+        w.indent();
+        w.line("results.addAll(findDescendantsBounded(child, parserClass));");
+        w.dedent();
+        w.line("}");
+        w.dedent();
+        w.line("}");
+        w.line("return results;");
+        w.dedent();
+        w.line("}");
         w.blankLine();
 
         w.line("// Collects rule-level (top-level) occurrences of parserClass: once a child");
@@ -945,7 +1030,11 @@ class MapperRuleEmitter {
         w.line("return null;");
         w.dedent();
         w.line("}");
-        w.line("return findDescendantByIndex(token, parserClass, index);");
+        // Fallback for captures nested under anonymous wrappers (Optional/Group/Repeat): a
+        // bounded descendant search that does NOT cross capture boundaries, so an absent
+        // capture at this level cannot leak into a nested mapped sub-expression.
+        w.line("List<Token> bounded = findDescendantsBounded(token, parserClass);");
+        w.line("return index < bounded.size() ? bounded.get(index) : null;");
         w.dedent();
         w.line("}");
         w.blankLine();

--- a/unlaxer-dsl/src/test/resources/golden/mapper_right_assoc_snapshot.java.txt
+++ b/unlaxer-dsl/src/test/resources/golden/mapper_right_assoc_snapshot.java.txt
@@ -204,6 +204,25 @@ public class SnapshotRightAssocMapper {
     // Utilities
     // =========================================================================
 
+    private static final java.util.Set<Class<?>> CAPTURE_BOUNDARY_PARSERS = java.util.Set.of(
+        SnapshotRightAssocParsers.ExprParser.class
+    );
+
+    static List<Token> findDescendantsBounded(Token token, Class<? extends Parser> parserClass) {
+        List<Token> results = new ArrayList<>();
+        if (token == null) {
+            return results;
+        }
+        for (Token child : token.filteredChildren) {
+            if (child.parser.getClass() == parserClass) {
+                results.add(child);
+            } else if (!CAPTURE_BOUNDARY_PARSERS.contains(child.parser.getClass())) {
+                results.addAll(findDescendantsBounded(child, parserClass));
+            }
+        }
+        return results;
+    }
+
     // Collects rule-level (top-level) occurrences of parserClass: once a child
     // matches, we do NOT recurse into it, so a captured operand's own nested
     // same-class descendants are not counted. This keeps positional captures
@@ -282,7 +301,8 @@ public class SnapshotRightAssocMapper {
         if (!direct.isEmpty()) {
             return null;
         }
-        return findDescendantByIndex(token, parserClass, index);
+        List<Token> bounded = findDescendantsBounded(token, parserClass);
+        return index < bounded.size() ? bounded.get(index) : null;
     }
 
     static String firstTokenText(Token token) {

--- a/unlaxer-dsl/src/test/resources/golden/mapper_snapshot.java.txt
+++ b/unlaxer-dsl/src/test/resources/golden/mapper_snapshot.java.txt
@@ -214,6 +214,26 @@ public class SnapshotMapper {
     // Utilities
     // =========================================================================
 
+    private static final java.util.Set<Class<?>> CAPTURE_BOUNDARY_PARSERS = java.util.Set.of(
+        SnapshotParsers.ExprParser.class,
+        SnapshotParsers.TermParser.class
+    );
+
+    static List<Token> findDescendantsBounded(Token token, Class<? extends Parser> parserClass) {
+        List<Token> results = new ArrayList<>();
+        if (token == null) {
+            return results;
+        }
+        for (Token child : token.filteredChildren) {
+            if (child.parser.getClass() == parserClass) {
+                results.add(child);
+            } else if (!CAPTURE_BOUNDARY_PARSERS.contains(child.parser.getClass())) {
+                results.addAll(findDescendantsBounded(child, parserClass));
+            }
+        }
+        return results;
+    }
+
     // Collects rule-level (top-level) occurrences of parserClass: once a child
     // matches, we do NOT recurse into it, so a captured operand's own nested
     // same-class descendants are not counted. This keeps positional captures
@@ -292,7 +312,8 @@ public class SnapshotMapper {
         if (!direct.isEmpty()) {
             return null;
         }
-        return findDescendantByIndex(token, parserClass, index);
+        List<Token> bounded = findDescendantsBounded(token, parserClass);
+        return index < bounded.size() ? bounded.get(index) : null;
     }
 
     static String firstTokenText(Token token) {


### PR DESCRIPTION
## 概要
ネスト slice の value 解決を AST 経路で完成（#32）。

### 1. 多ルール plain mapping ディスパッチ
同一 AST クラスに**異なる capture 構造**の非 assoc ルールが2つある場合（`SliceExpr`: `SliceBaseExpression` の `@value`=SliceBaseReceiver / `SliceNestedExpression` の `@value`=SliceBaseExpression＝mapped クラス自身）、`to<Class>` は代表1ルールからしか生成されず他方を誤マップ（`'gateman'[::-1][0:4]` が内側 slice を脱落）。`emitPlainMappingBody` が追加ルールを `token.parser.getClass()` でディスパッチ（resolution を `emitPlainMappingResolution` に抽出）、代表ルールは無ガード fallback。単一ルール・構造同一ルール（`IfExpr` の `ArgumentTernary`）は挙動不変。

### 2. bounded capture fallback
`findCapturedToken` のグローバル fallback が、外側 slice の**不在の `@step`**（`[0:4]`）を内側 `[::-1]` の step にマッチさせていた。fallback を `findDescendantsBounded`（`CAPTURE_BOUNDARY_PARSERS`＝全 mapped-rule parser クラスで停止）に。ラッパーネスト capture は引き続き解決。`emitUtilities(parsersClass, mappedRuleNames)`。

## 検証
- unlaxer-dsl 746 緑（golden 更新）、内部フルビルド緑、CompileVerification 緑。
- tinyexpression baseline ゲート緑（新規失敗ゼロ）。
- if-source shadow OFF の calc 失敗：2 → **1**（testStringSlice/testMin/testMax 解消、残り testTypeInference=var宣言のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)