### PR TITLE
perf(common): StringSource.peek drop redundant double-allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versions are published to Maven Central (`org.unlaxer:unlaxer-common`, `org.unla
 
 ## [Unreleased]
 
+### Changed
+- `StringSource.peek` no longer double-allocates: it returned `new StringSource(this, subSource(...), offset)`, wrapping an already-equivalent `subSource` in a second `StringSource` (a redundant String + int[] copy on every peek — a hot path in deeply nested grammars). Now returns the single `subSource` directly. Byte-for-byte equivalent; full `unlaxer-common` suite green (108 files). NOTE: this halves peek allocation but does **not** by itself bring the deeply nested-`if` formula (tinyexpression #19 example 5) under a second — that case is GC/allocation-bound and needs dedicated profiling (its cost is not `(rule,position)` re-derivation, which memoization already removes).
+
 ---
 
 ## [3.0.10] - 2026-06-28

--- a/unlaxer-common/src/main/java/org/unlaxer/StringSource.java
+++ b/unlaxer-common/src/main/java/org/unlaxer/StringSource.java
@@ -280,14 +280,15 @@ public class StringSource implements Source {
 
   @Override
   public Source peek(CodePointIndex startIndexInclusive, CodePointLength length) {
-    CodePointOffset offset = new CodePointOffset(startIndexInclusive);
-
+    // subSource(start, length) already produces a StringSource over codePoints[start, start+length)
+    // with parent=this and the same root offset; the previous implementation wrapped that result in
+    // a SECOND StringSource at the same offset, doubling the String + int[] copies on every peek
+    // (the dominant allocation in deeply nested grammars — #19/#40). The wrap is redundant: the
+    // single subSource is byte-for-byte equivalent. (perf #40 follow-up)
     if (startIndexInclusive.value() + length.value() > codePoints.length) {
-      return new StringSource(this,
-          subSource(startIndexInclusive, new CodePointLength(0)),
-          offset);
+      return subSource(startIndexInclusive, new CodePointLength(0));
     }
-    return new StringSource(this, subSource(startIndexInclusive, length), offset);
+    return subSource(startIndexInclusive, length);
   }
 
   @Override


### PR DESCRIPTION
peek() wrapped an already-equivalent `subSource` in a second `StringSource`, doubling the String + int[] copy on every peek (hot path in deeply nested grammars). Now returns the single `subSource` directly — byte-for-byte equivalent, full unlaxer-common suite green (108 files).

Honest scope: halves peek allocation but does NOT alone bring tinyexpression #19 example 5 (deeply nested-if) under a second. That formula is GC/allocation-bound (parse times swing 12–30s) and its cost is not `(rule,position)` re-derivation (memoization already removes that) nor the peek double-wrap — it needs dedicated profiling. This is a safe standalone cleanup; not released (no version bump).

関連: unlaxer-parser #40, opaopa6969/tinyexpression#19/#38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)