### PR TITLE
feat(codegen): memoize mapToken + drop per-token reflection (tinyexpression #49); release 3.0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 	</developers>
 
 	<properties>
-		<revision>3.0.10</revision> <!-- ここを変えるだけで全体が変わるようになります -->
+		<revision>3.0.11</revision> <!-- ここを変えるだけで全体が変わるようになります -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>

--- a/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperGenerator.java
+++ b/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperGenerator.java
@@ -72,6 +72,10 @@ public class MapperGenerator implements CodeGenerator {
         sb.append("    private ").append(mapperClass).append("() {}\n\n");
         sb.append("    private static final java.util.IdentityHashMap<Object, int[]> NODE_SOURCE_SPANS =\n");
         sb.append("        new java.util.IdentityHashMap<>();\n\n");
+        // Per-parse memo of token -> mapped AST node; see mapToken. Cleared at the start of parse().
+        // (tinyexpression #49)
+        sb.append("    private static final java.util.IdentityHashMap<Token, ").append(astClass).append("> MAP_MEMO =\n");
+        sb.append("        new java.util.IdentityHashMap<>();\n\n");
 
         String rootClassName = rootRule.flatMap(MapperElementUtil::getMappingAnnotation)
             .map(m -> astClass + "." + m.className())
@@ -119,6 +123,7 @@ public class MapperGenerator implements CodeGenerator {
         sb.append("    }\n\n");
         sb.append("    public static ").append(rootClassName).append(" parse(String source, String preferredAstSimpleName) {\n");
         sb.append("        NODE_SOURCE_SPANS.clear();\n");
+        sb.append("        MAP_MEMO.clear();\n");
         sb.append("        Parser rootParser = ").append(parsersClass).append(".getRootParser();\n");
         sb.append("        ParseContext context = new ParseContext(createRootSourceCompat(source));\n");
         sb.append("        Parsed parsed;\n");

--- a/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperRuleEmitter.java
+++ b/unlaxer-dsl/src/main/java/org/unlaxer/dsl/codegen/MapperRuleEmitter.java
@@ -28,7 +28,30 @@ class MapperRuleEmitter {
     static String emitMapTokenMethod(String astClass, String parsersClass,
             Map<String, List<RuleDecl>> allMappingRules) {
         IndentedWriter w = new IndentedWriter(1);
+        // Memoized wrapper. mapToken is otherwise re-invoked on the same token objects O(depth) times
+        // (findBestMappedToken probes every node, and each mapping method resolves its operands via
+        // findBestMappedToken again), so a deeply nested expression re-constructs the same subtrees
+        // millions of times. Memoizing by token identity collapses that to one construction per token.
+        // (tinyexpression #49)
         w.line("private static " + astClass + " mapToken(Token token) {");
+        w.indent();
+        w.line("if (token == null) {");
+        w.indent();
+        w.line("return null;");
+        w.dedent();
+        w.line("}");
+        w.line("if (MAP_MEMO.containsKey(token)) {");
+        w.indent();
+        w.line("return MAP_MEMO.get(token);");
+        w.dedent();
+        w.line("}");
+        w.line(astClass + " memoized = mapTokenUncached(token);");
+        w.line("MAP_MEMO.put(token, memoized);");
+        w.line("return memoized;");
+        w.dedent();
+        w.line("}");
+        w.blankLine();
+        w.line("private static " + astClass + " mapTokenUncached(Token token) {");
         w.indent();
         w.line("if (token == null) {");
         w.indent();
@@ -1067,6 +1090,11 @@ class MapperRuleEmitter {
         w.line("}");
         w.blankLine();
 
+        // Token is always org.unlaxer.Token (imported in the generated mapper): getToken()/tokenString/
+        // source are public and stable, so call them directly. The previous getClass().getMethod/getField
+        // reflection allocated a Method/Field + PublicMethods$MethodList + Class[] on every call; under
+        // deeply nested expressions this was, together with the per-token re-mapping, the dominant
+        // allocation that drove parse time and GC. (tinyexpression #49)
         w.line("static String tokenTextCompat(Token token) {");
         w.indent();
         w.line("if (token == null) {");
@@ -1074,43 +1102,26 @@ class MapperRuleEmitter {
         w.line("return null;");
         w.dedent();
         w.line("}");
-        w.line("try {");
+        w.line("Optional<String> tokenValue = token.getToken();");
+        w.line("if (tokenValue != null && tokenValue.isPresent()) {");
         w.indent();
-        w.line("java.lang.reflect.Method m = token.getClass().getMethod(\"getToken\");");
-        w.line("Object value = m.invoke(token);");
-        w.line("if (value instanceof Optional<?> optional && optional.isPresent()) {");
-        w.indent();
-        w.line("Object v = optional.get();");
+        w.line("String v = tokenValue.get();");
         w.line("return v == null ? null : String.valueOf(v);");
         w.dedent();
         w.line("}");
-        w.dedent();
-        w.line("} catch (Throwable ignored) {}");
-        w.line("try {");
+        w.line("if (token.tokenString != null && token.tokenString.isPresent()) {");
         w.indent();
-        w.line("java.lang.reflect.Field f = token.getClass().getField(\"tokenString\");");
-        w.line("Object value = f.get(token);");
-        w.line("if (value instanceof Optional<?> optional && optional.isPresent()) {");
-        w.indent();
-        w.line("Object v = optional.get();");
+        w.line("String v = token.tokenString.get();");
         w.line("return v == null ? null : String.valueOf(v);");
         w.dedent();
         w.line("}");
-        w.dedent();
-        w.line("} catch (Throwable ignored) {}");
-        w.line("try {");
-        w.indent();
-        w.line("java.lang.reflect.Field f = token.getClass().getField(\"source\");");
-        w.line("Object src = f.get(token);");
+        w.line("org.unlaxer.Source src = token.source;");
         w.line("if (src != null) {");
         w.indent();
-        w.line("java.lang.reflect.Method m = src.getClass().getMethod(\"sourceAsString\");");
-        w.line("Object v = m.invoke(src);");
+        w.line("String v = src.sourceAsString();");
         w.line("return v == null ? null : String.valueOf(v);");
         w.dedent();
         w.line("}");
-        w.dedent();
-        w.line("} catch (Throwable ignored) {}");
         w.line("return null;");
         w.dedent();
         w.line("}");
@@ -1131,37 +1142,19 @@ class MapperRuleEmitter {
         w.line("return 0;");
         w.dedent();
         w.line("}");
-        w.line("try {");
-        w.indent();
-        w.line("java.lang.reflect.Field sourceField = token.getClass().getField(\"source\");");
-        w.line("Object source = sourceField.get(token);");
+        w.line("org.unlaxer.Source source = token.source;");
         w.line("if (source == null) {");
         w.indent();
         w.line("return 0;");
         w.dedent();
         w.line("}");
-        w.line("java.lang.reflect.Method offsetMethod = source.getClass().getMethod(\"offsetFromRoot\");");
-        w.line("Object offset = offsetMethod.invoke(source);");
+        w.line("org.unlaxer.CodePointOffset offset = source.offsetFromRoot();");
         w.line("if (offset == null) {");
         w.indent();
         w.line("return 0;");
         w.dedent();
         w.line("}");
-        w.line("java.lang.reflect.Method valueMethod = offset.getClass().getMethod(\"value\");");
-        w.line("Object value = valueMethod.invoke(offset);");
-        w.line("if (value instanceof Integer i) {");
-        w.indent();
-        w.line("return i;");
-        w.dedent();
-        w.line("}");
-        w.line("if (value instanceof Number n) {");
-        w.indent();
-        w.line("return n.intValue();");
-        w.dedent();
-        w.line("}");
-        w.dedent();
-        w.line("} catch (Throwable ignored) {}");
-        w.line("return 0;");
+        w.line("return offset.value();");
         w.dedent();
         w.line("}");
         w.blankLine();

--- a/unlaxer-dsl/src/test/resources/golden/mapper_right_assoc_snapshot.java.txt
+++ b/unlaxer-dsl/src/test/resources/golden/mapper_right_assoc_snapshot.java.txt
@@ -21,6 +21,9 @@ public class SnapshotRightAssocMapper {
     private static final java.util.IdentityHashMap<Object, int[]> NODE_SOURCE_SPANS =
         new java.util.IdentityHashMap<>();
 
+    private static final java.util.IdentityHashMap<Token, SnapshotRightAssocAST> MAP_MEMO =
+        new java.util.IdentityHashMap<>();
+
     // =========================================================================
     // Entry Point
     // =========================================================================
@@ -31,6 +34,7 @@ public class SnapshotRightAssocMapper {
 
     public static SnapshotRightAssocAST.PowNode parse(String source, String preferredAstSimpleName) {
         NODE_SOURCE_SPANS.clear();
+        MAP_MEMO.clear();
         Parser rootParser = SnapshotRightAssocParsers.getRootParser();
         ParseContext context = new ParseContext(createRootSourceCompat(source));
         Parsed parsed;
@@ -58,6 +62,18 @@ public class SnapshotRightAssocMapper {
     }
 
     private static SnapshotRightAssocAST mapToken(Token token) {
+        if (token == null) {
+            return null;
+        }
+        if (MAP_MEMO.containsKey(token)) {
+            return MAP_MEMO.get(token);
+        }
+        SnapshotRightAssocAST memoized = mapTokenUncached(token);
+        MAP_MEMO.put(token, memoized);
+        return memoized;
+    }
+
+    private static SnapshotRightAssocAST mapTokenUncached(Token token) {
         if (token == null) {
             return null;
         }
@@ -326,31 +342,20 @@ public class SnapshotRightAssocMapper {
         if (token == null) {
             return null;
         }
-        try {
-            java.lang.reflect.Method m = token.getClass().getMethod("getToken");
-            Object value = m.invoke(token);
-            if (value instanceof Optional<?> optional && optional.isPresent()) {
-                Object v = optional.get();
-                return v == null ? null : String.valueOf(v);
-            }
-        } catch (Throwable ignored) {}
-        try {
-            java.lang.reflect.Field f = token.getClass().getField("tokenString");
-            Object value = f.get(token);
-            if (value instanceof Optional<?> optional && optional.isPresent()) {
-                Object v = optional.get();
-                return v == null ? null : String.valueOf(v);
-            }
-        } catch (Throwable ignored) {}
-        try {
-            java.lang.reflect.Field f = token.getClass().getField("source");
-            Object src = f.get(token);
-            if (src != null) {
-                java.lang.reflect.Method m = src.getClass().getMethod("sourceAsString");
-                Object v = m.invoke(src);
-                return v == null ? null : String.valueOf(v);
-            }
-        } catch (Throwable ignored) {}
+        Optional<String> tokenValue = token.getToken();
+        if (tokenValue != null && tokenValue.isPresent()) {
+            String v = tokenValue.get();
+            return v == null ? null : String.valueOf(v);
+        }
+        if (token.tokenString != null && token.tokenString.isPresent()) {
+            String v = token.tokenString.get();
+            return v == null ? null : String.valueOf(v);
+        }
+        org.unlaxer.Source src = token.source;
+        if (src != null) {
+            String v = src.sourceAsString();
+            return v == null ? null : String.valueOf(v);
+        }
         return null;
     }
 
@@ -363,27 +368,15 @@ public class SnapshotRightAssocMapper {
         if (token == null) {
             return 0;
         }
-        try {
-            java.lang.reflect.Field sourceField = token.getClass().getField("source");
-            Object source = sourceField.get(token);
-            if (source == null) {
-                return 0;
-            }
-            java.lang.reflect.Method offsetMethod = source.getClass().getMethod("offsetFromRoot");
-            Object offset = offsetMethod.invoke(source);
-            if (offset == null) {
-                return 0;
-            }
-            java.lang.reflect.Method valueMethod = offset.getClass().getMethod("value");
-            Object value = valueMethod.invoke(offset);
-            if (value instanceof Integer i) {
-                return i;
-            }
-            if (value instanceof Number n) {
-                return n.intValue();
-            }
-        } catch (Throwable ignored) {}
-        return 0;
+        org.unlaxer.Source source = token.source;
+        if (source == null) {
+            return 0;
+        }
+        org.unlaxer.CodePointOffset offset = source.offsetFromRoot();
+        if (offset == null) {
+            return 0;
+        }
+        return offset.value();
     }
 
     static <T> T registerNodeSourceSpan(T node, Token token) {

--- a/unlaxer-dsl/src/test/resources/golden/mapper_snapshot.java.txt
+++ b/unlaxer-dsl/src/test/resources/golden/mapper_snapshot.java.txt
@@ -21,6 +21,9 @@ public class SnapshotMapper {
     private static final java.util.IdentityHashMap<Object, int[]> NODE_SOURCE_SPANS =
         new java.util.IdentityHashMap<>();
 
+    private static final java.util.IdentityHashMap<Token, SnapshotAST> MAP_MEMO =
+        new java.util.IdentityHashMap<>();
+
     // =========================================================================
     // Entry Point
     // =========================================================================
@@ -31,6 +34,7 @@ public class SnapshotMapper {
 
     public static SnapshotAST.ExprNode parse(String source, String preferredAstSimpleName) {
         NODE_SOURCE_SPANS.clear();
+        MAP_MEMO.clear();
         Parser rootParser = SnapshotParsers.getRootParser();
         ParseContext context = new ParseContext(createRootSourceCompat(source));
         Parsed parsed;
@@ -58,6 +62,18 @@ public class SnapshotMapper {
     }
 
     private static SnapshotAST mapToken(Token token) {
+        if (token == null) {
+            return null;
+        }
+        if (MAP_MEMO.containsKey(token)) {
+            return MAP_MEMO.get(token);
+        }
+        SnapshotAST memoized = mapTokenUncached(token);
+        MAP_MEMO.put(token, memoized);
+        return memoized;
+    }
+
+    private static SnapshotAST mapTokenUncached(Token token) {
         if (token == null) {
             return null;
         }
@@ -337,31 +353,20 @@ public class SnapshotMapper {
         if (token == null) {
             return null;
         }
-        try {
-            java.lang.reflect.Method m = token.getClass().getMethod("getToken");
-            Object value = m.invoke(token);
-            if (value instanceof Optional<?> optional && optional.isPresent()) {
-                Object v = optional.get();
-                return v == null ? null : String.valueOf(v);
-            }
-        } catch (Throwable ignored) {}
-        try {
-            java.lang.reflect.Field f = token.getClass().getField("tokenString");
-            Object value = f.get(token);
-            if (value instanceof Optional<?> optional && optional.isPresent()) {
-                Object v = optional.get();
-                return v == null ? null : String.valueOf(v);
-            }
-        } catch (Throwable ignored) {}
-        try {
-            java.lang.reflect.Field f = token.getClass().getField("source");
-            Object src = f.get(token);
-            if (src != null) {
-                java.lang.reflect.Method m = src.getClass().getMethod("sourceAsString");
-                Object v = m.invoke(src);
-                return v == null ? null : String.valueOf(v);
-            }
-        } catch (Throwable ignored) {}
+        Optional<String> tokenValue = token.getToken();
+        if (tokenValue != null && tokenValue.isPresent()) {
+            String v = tokenValue.get();
+            return v == null ? null : String.valueOf(v);
+        }
+        if (token.tokenString != null && token.tokenString.isPresent()) {
+            String v = token.tokenString.get();
+            return v == null ? null : String.valueOf(v);
+        }
+        org.unlaxer.Source src = token.source;
+        if (src != null) {
+            String v = src.sourceAsString();
+            return v == null ? null : String.valueOf(v);
+        }
         return null;
     }
 
@@ -374,27 +379,15 @@ public class SnapshotMapper {
         if (token == null) {
             return 0;
         }
-        try {
-            java.lang.reflect.Field sourceField = token.getClass().getField("source");
-            Object source = sourceField.get(token);
-            if (source == null) {
-                return 0;
-            }
-            java.lang.reflect.Method offsetMethod = source.getClass().getMethod("offsetFromRoot");
-            Object offset = offsetMethod.invoke(source);
-            if (offset == null) {
-                return 0;
-            }
-            java.lang.reflect.Method valueMethod = offset.getClass().getMethod("value");
-            Object value = valueMethod.invoke(offset);
-            if (value instanceof Integer i) {
-                return i;
-            }
-            if (value instanceof Number n) {
-                return n.intValue();
-            }
-        } catch (Throwable ignored) {}
-        return 0;
+        org.unlaxer.Source source = token.source;
+        if (source == null) {
+            return 0;
+        }
+        org.unlaxer.CodePointOffset offset = source.offsetFromRoot();
+        if (offset == null) {
+            return 0;
+        }
+        return offset.value();
     }
 
     static <T> T registerNodeSourceSpan(T node, Token token) {


### PR DESCRIPTION
## 背景 (tinyexpression #49)

tinyexpression #19 例5（深いネスト if）は packrat parse メモ化 (#40) ON でも **12–30s**（実行ごとに大きくばらつく＝GC圧のシグネチャ）。#49 で **実プロファイリング**（JFR alloc+cpu）したところ、律速は **parse 段ではなく mapping 段の冗長な再マッピング**だった。

`findBestMappedToken` が各ノードで `mapToken` を呼び、各 mapping メソッドが operand を再び `findBestMappedToken` 経由で解決するため、深いネスト式は同一トークンを**数百万回**マップする（#5: ~100 ノードの AST に対し **mapToken 構築 1,010万回**）。この約1000万倍が2つの per-call コストに乗算:

1. `tokenTextCompat`/`tokenStartOffsetCompat` の `getClass().getMethod/getField` リフレクション → `Method`/`WeakReference`/`PublicMethods$MethodList` 割当の嵐（割当上位）
2. ノード毎の `new int[]` を無制限の `NODE_SOURCE_SPANS` `IdentityHashMap` に put → `IdentityHashMap.resize` が CPU の **56%**

（推測されていた `StringSource` コピーは JFR で**反証**。）

## 変更（`MapperGenerator` / `MapperRuleEmitter`）

- **A. `mapToken` のトークン単位メモ化**（`MAP_MEMO`、parse 冒頭で clear）— 1,010万構築を1トークン1回に短絡。
- **B. `token*Compat` のリフレクション撤廃** — 生成 mapper は既に `org.unlaxer.Token` を import 済みで `getToken()`/`tokenString`/`source` は public・安定。直接呼び出しに置換。

## 検証

- **end-to-end（本物の生成パイプライン）**: tinyexpression #5 **12–30s → ~30ms**。fraud-formula スイート全式 <0.5s。
- **正しさ**: memo 有無で生成 AST がバイト単位一致。
- ゴールデン mapper スナップショット2件を再生成（出力変化＝意図どおり）。`unlaxer-dsl` フルスイート緑。
- revision を **3.0.11** に bump（common + dsl）。Central デプロイ済み（deploymentId 検証通過、autoPublish）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)